### PR TITLE
issue 8 nosetests not installed vagrant

### DIFF
--- a/scripts/vagrant/general_setup.sh
+++ b/scripts/vagrant/general_setup.sh
@@ -10,7 +10,7 @@ echo "Installing GIT..."
 sudo apt-get install -y git
 
 echo "Installing Python tools..."
-sudo apt-get install -y python-dev libxml2-dev libxslt1-dev zlib1g-dev python-virtualenv
+sudo apt-get install -y python-dev python-pip libxml2-dev libxslt1-dev zlib1g-dev
 
 echo "rsyncing default Vagrant synced folder to vagrant user home..."
 rsync -a /vagrant/ /home/vagrant

--- a/scripts/vagrant/project_setup.sh
+++ b/scripts/vagrant/project_setup.sh
@@ -3,13 +3,9 @@
 
 set -e # Exit script immediately on first error.
 
-# echo "Creating/activating a Python virtual environment..."
-virtualenv env
-source env/bin/activate
-
 echo "Installing project dependencies..."
-pip install -r requirements.txt
-pip install git+https://github.com/vmalloc/mongomock.git@master # use master instead of 2.0.0
+sudo pip install -r requirements.txt
+sudo pip install git+https://github.com/vmalloc/mongomock.git@master # use master instead of 2.0.0
 
 # NOTE: if config/config.ini.template changes, this needs to change also
 echo "Generating config file for development..." 


### PR DESCRIPTION
problem: Python packages were being installed within a virtualenv within the VM. This is unecessary because the VM is already provisioned with tools specific to this project.

solution: removed setup of python virtualenv within the Vagrant VM